### PR TITLE
fallback on client ip if none specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-client-ip"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eefda7e2b27e1bda4d6fa8a06b50803b8793769045918bc37ad062d48a6efac"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "serde",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +347,7 @@ name = "dyndns"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-client-ip",
  "chrono",
  "clap",
  "clap-verbosity-flag",
@@ -430,6 +442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
 ]
 
 [[package]]
@@ -984,6 +1006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1529,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 axum = { version = "0.7.5", features = ["macros"] }
+axum-client-ip = "0.6.1"
 chrono = "0.4.39"
 clap = { version = "4.5.20", features = ["derive"] }
 clap-verbosity-flag = "3.0.0"


### PR DESCRIPTION
Mimic DuckDNS [behaviour](https://www.duckdns.org/spec.jsp):
> If you do not specify the IP address, then it will be detected - this only works for IPv4 addresses.

Excepted that it works both for IPv4 and IPv6 (depending on the source IP).

```bash
❯ curl -4s "https://f756-2001-861-5001-1190-6520-dc5-7c0a-62b1.ngrok-free.app?token=$TOKEN&subdomain=0b8dcbd3" | jq
{
  "message": "OK",
  "domain": "0b8dcbd3.dyndns.nxthdr.dev",
  "clear": false,
  "records": [
    {
      "type": "A",
      "content": "176.168.139.101"
    }
  ]
}
```

```bash
❯ curl -6s "https://f756-2001-861-5001-1190-6520-dc5-7c0a-62b1.ngrok-free.app?token=$TOKEN&subdomain=0b8dcbd3" | jq
{
  "message": "OK",
  "domain": "0b8dcbd3.dyndns.nxthdr.dev",
  "clear": false,
  "records": [
    {
      "type": "AAAA",
      "content": "2001:861:5001:1190:6520:dc5:7c0a:62b1"
    }
  ]
}
```